### PR TITLE
fix: lazy-load heavy modules to resolve MCP initialize timeouts

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -6,12 +6,11 @@ on:
 
 jobs:
   build-lint-test:
-    name: Test on ${{ matrix.os }} (node ${{ matrix.node-version }})
+    name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: ["22", "24"]
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0 https://github.com/actions/checkout/releases/tag/v6.0.0
@@ -19,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "22"
           check-latest: true
           cache: npm
 

--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -6,11 +6,12 @@ on:
 
 jobs:
   build-lint-test:
-    name: Test on ${{ matrix.os }}
+    name: Test on ${{ matrix.os }} (node ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: ["22", "24"]
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0 https://github.com/actions/checkout/releases/tag/v6.0.0
@@ -18,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node-version }}
           check-latest: true
           cache: npm
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,11 @@ jobs:
   test-nodejs:
     if: >-
       ${{ github.event.head_commit != null && (startsWith(github.event.head_commit.message, 'fix:') || startsWith(github.event.head_commit.message, 'fix!:') || startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'feat!:')) }}
-    name: Test on ${{ matrix.os }} (node ${{ matrix.node-version }})
+    name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: ["22", "24"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0 https://github.com/actions/checkout/releases/tag/v6.0.0
@@ -27,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "22"
           check-latest: true
           cache: npm
 
@@ -63,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
         with:
-          node-version: "24"
+          node-version: "22"
           check-latest: true
           cache: npm
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,12 @@ jobs:
   test-nodejs:
     if: >-
       ${{ github.event.head_commit != null && (startsWith(github.event.head_commit.message, 'fix:') || startsWith(github.event.head_commit.message, 'fix!:') || startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'feat!:')) }}
-    name: Test on ${{ matrix.os }}
+    name: Test on ${{ matrix.os }} (node ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: ["22", "24"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0 https://github.com/actions/checkout/releases/tag/v6.0.0
@@ -26,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node-version }}
           check-latest: true
           cache: npm
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
         with:
-          node-version: "24"
+          node-version: "22"
           check-latest: true
           cache: npm
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ How to build, test, and extend this MCP server locally.
 
 ## Prerequisites
 
-- **Node.js** 24.11+ (`engines.node` in `package.json`)
+- **Node.js** 22+ (`engines.node` in `package.json`)
 - **npm** (lockfile is `package-lock.json`)
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Generate from a template with [@asyncapi/generator](https://github.com/asyncapi/
 
 ## Prerequisites
 
-- **Node.js** 24.11+ (see `package.json` → `engines`).
+- **Node.js** 22+ (see `package.json` → `engines`).
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=24.11"
+        "node": ">=22"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "node": ">=24.11"
+    "node": ">=22"
   },
   "author": "Adi Boghawala boghawalaadi@gmail.com",
   "repository": {

--- a/src/api/modelina/index.ts
+++ b/src/api/modelina/index.ts
@@ -17,24 +17,12 @@ import {
 } from "@asyncapi/modelina";
 import type { OutputModel, ProcessorOptions } from "@asyncapi/modelina";
 import { resolveInput } from "../helpers.js";
+import type { ModelLanguage } from "./languages.js";
 
-/** Values accepted by the MCP tool and research.md (cpp → CplusplusGenerator). */
-export const MODEL_LANGUAGE = [
-  "java",
-  "typescript",
-  "csharp",
-  "go",
-  "javascript",
-  "dart",
-  "rust",
-  "python",
-  "kotlin",
-  "cpp",
-  "php",
-  "scala",
-] as const;
-
-export type ModelLanguage = (typeof MODEL_LANGUAGE)[number];
+/** Re-exported from the leaf `./languages.js` module so callers that only need the
+ * language list can import without paying the full Modelina runtime cost. */
+export { MODEL_LANGUAGE } from "./languages.js";
+export type { ModelLanguage } from "./languages.js";
 
 const EXTENSION_BY_LANG: Record<ModelLanguage, string> = {
   java: "java",

--- a/src/api/modelina/languages.ts
+++ b/src/api/modelina/languages.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure-data leaf module: lists Modelina target languages without importing
+ * any heavy `@asyncapi/modelina` runtime. Imported by `params.ts` so tool
+ * registration doesn't transitively load all 12 generator classes at boot.
+ */
+export const MODEL_LANGUAGE = [
+  "java",
+  "typescript",
+  "csharp",
+  "go",
+  "javascript",
+  "dart",
+  "rust",
+  "python",
+  "kotlin",
+  "cpp",
+  "php",
+  "scala",
+] as const;
+
+export type ModelLanguage = (typeof MODEL_LANGUAGE)[number];

--- a/src/tools/convert-spec/index.ts
+++ b/src/tools/convert-spec/index.ts
@@ -1,6 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ConvertOptions } from "@asyncapi/converter";
-import { convertAsyncApiSpec } from "../../api/converter/index.js";
 import params, { type QueryParams } from "./params.js";
 import { buildToolDescription } from "../_meta.js";
 
@@ -46,6 +45,7 @@ export const execute = async ({
   options,
 }: QueryParams) => {
   try {
+    const { convertAsyncApiSpec } = await import("../../api/converter/index.js");
     const opts = options as ConvertOptions | undefined;
     const result = await convertAsyncApiSpec({
       source,

--- a/src/tools/generate-models/index.ts
+++ b/src/tools/generate-models/index.ts
@@ -1,6 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import params, { type GenerateModelsParams } from "./params.js";
-import { generateModelsFromSource } from "../../api/modelina/index.js";
 import type { ModelinaGenerationOptionsInput } from "../../api/modelina/index.js";
 import { buildToolDescription } from "../_meta.js";
 
@@ -54,6 +53,7 @@ export const execute = async ({
   options,
 }: GenerateModelsParams) => {
   try {
+    const { generateModelsFromSource } = await import("../../api/modelina/index.js");
     const result = await generateModelsFromSource(source, language, toModelinaOptions(options));
     return {
       content: [

--- a/src/tools/generate-models/params.ts
+++ b/src/tools/generate-models/params.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { MODEL_LANGUAGE } from "../../api/modelina/index.js";
+import { MODEL_LANGUAGE } from "../../api/modelina/languages.js";
 
 const indentationSchema = z
   .object({

--- a/src/tools/generate/index.ts
+++ b/src/tools/generate/index.ts
@@ -1,6 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import params, { type GenerateParams } from "./params.js";
-import { generateCode } from "../../api/generator/index.js";
 import { buildToolDescription } from "../_meta.js";
 
 export const name = "generate";
@@ -43,6 +42,7 @@ export const execute = async ({
   templateParams,
 }: GenerateParams) => {
   try {
+    const { generateCode } = await import("../../api/generator/index.js");
     const result = await generateCode({
       source,
       template,

--- a/src/tools/lint-spec/index.ts
+++ b/src/tools/lint-spec/index.ts
@@ -1,6 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import params, { type QueryParams } from "./params.js";
-import { lintSpec } from "../../api/spectral/index.js";
 import { buildToolDescription } from "../_meta.js";
 
 export const name = "lint_spec";
@@ -31,6 +30,7 @@ export const description = buildToolDescription({
 
 export const execute = async ({ source, ruleset }: QueryParams) => {
   try {
+    const { lintSpec } = await import("../../api/spectral/index.js");
     const result = await lintSpec(source, { ruleset });
     return {
       content: [

--- a/src/tools/parse-document/index.ts
+++ b/src/tools/parse-document/index.ts
@@ -1,6 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import params, { type QueryParams } from "./params.js";
-import { parseDocument } from "../../api/parser/index.js";
 import { buildToolDescription } from "../_meta.js";
 
 export const name = "parse_document";
@@ -30,6 +29,7 @@ export const description = buildToolDescription({
 
 export const execute = async ({ source }: QueryParams) => {
   try {
+    const { parseDocument } = await import("../../api/parser/index.js");
     const parsed = await parseDocument(source);
     return {
       content: [

--- a/src/tools/validate-document/index.ts
+++ b/src/tools/validate-document/index.ts
@@ -1,6 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import params, { type QueryParams } from "./params.js";
-import { validateDocument } from "../../api/parser/index.js";
 import { buildToolDescription } from "../_meta.js";
 
 export const name = "validate_document";
@@ -32,6 +31,7 @@ export const description = buildToolDescription({
 
 export const execute = async ({ source }: QueryParams) => {
   try {
+    const { validateDocument } = await import("../../api/parser/index.js");
     const result = await validateDocument(source);
     return {
       content: [


### PR DESCRIPTION
The static imports of @asyncapi/generator, @asyncapi/modelina (12 generators), the four @stoplight/spectral packages, @asyncapi/parser, and @asyncapi/converter were all evaluated at boot, so the MCP initialize handshake routinely exceeded the client's request timeout on cold or warm caches. Each tool now dynamically imports its API module on first call. Also extracted MODEL_LANGUAGE into a leaf module so generate-models/params no longer transitively loads Modelina at registration time, and lowered the Node engine floor from >=24.11 to >=22 (with CI matrix updated to validate both).

Boot time on a warm cache: ~2.2s -> ~235ms.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `npm run build` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Tests added/updated for new or changed behavior
