### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asyncapi-mcp-server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "asyncapi-mcp-server",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/converter": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asyncapi-mcp-server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "AsyncAPI MCP server — Model Context Protocol server for working with AsyncAPI: parse and validate documents, list templates, and generate code and docs (via @asyncapi/parser and @asyncapi/generator) for any MCP-compatible client",
   "bin": {
     "asyncapi-mcp-server": "dist/index.js"


### PR DESCRIPTION
Bumps `package.json` from `1.3.0` to `1.3.1` to match the [v1.3.1 release](https://github.com/Adi-204/asyncapi-mcp-server/releases/tag/v1.3.1) that was just published to [npm](https://www.npmjs.com/package/asyncapi-mcp-server) by `semantic-release`.

### Why this PR is opened manually

Normally `version-bump.yml` opens this PR automatically on the `release: published` event. GitHub Actions [intentionally suppresses](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) workflow events that originate from the default `GITHUB_TOKEN` (to prevent recursive workflow chains), so the release created by `semantic-release` did not trigger `version-bump.yml`.

To make it auto-trigger going forward, replace `GITHUB_TOKEN` in the `release.yml` step that runs `semantic-release` with a Personal Access Token (`repo` scope) or a GitHub App installation token, e.g.:

```yaml
env:
  GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}   # PAT with repo scope
```

That's a follow-up — this PR just unblocks the immediate sync.
