### PR TITLE
chore(release): v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asyncapi-mcp-server",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "asyncapi-mcp-server",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/converter": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asyncapi-mcp-server",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "AsyncAPI MCP server — Model Context Protocol server for working with AsyncAPI: parse and validate documents, list templates, and generate code and docs (via @asyncapi/parser and @asyncapi/generator) for any MCP-compatible client",
   "bin": {
     "asyncapi-mcp-server": "dist/index.js"


### PR DESCRIPTION
Version bump in package.json for release [v3.0.0](https://github.com/Adi-204/asyncapi-mcp-server/releases/tag/v3.0.0)